### PR TITLE
Bug/stats computation

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -2,4 +2,5 @@ test_basic
 test_ctx
 test_fail_fast
 test_no_tests
+test_no_groups
 test_check_include

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,4 +1,5 @@
 test_basic
 test_ctx
 test_fail_fast
+test_no_tests
 test_check_include

--- a/tests/test_no_groups.c
+++ b/tests/test_no_groups.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+#include <scrutiny/scrutiny.h>
+
+int
+main(int argc, char **argv)
+{
+    scrStats stats;
+    (void)argc;
+
+    printf("\nRunning %s\n\n", argv[0]);
+
+    scrRun(NULL, &stats);
+
+    return (stats.num_passed != 0 || stats.num_skipped != 0 || stats.num_failed != 0 ||
+            stats.num_errored != 0);
+}

--- a/tests/test_no_tests.c
+++ b/tests/test_no_tests.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+
+#include <scrutiny/scrutiny.h>
+
+int
+main(int argc, char **argv)
+{
+    scrStats stats;
+    (void)argc;
+
+    printf("\nRunning %s\n\n", argv[0]);
+
+    scrGroupCreate(NULL, NULL);
+
+    scrRun(NULL, &stats);
+
+    return (stats.num_passed != 0 || stats.num_skipped != 0 || stats.num_failed != 0 ||
+            stats.num_errored != 0);
+}


### PR DESCRIPTION
- Fixed the setting of the stats object when scrutiny cannot communicate with the group runner.
- Added a test for when there are no groups.
- Added a test for when a group has no tests.